### PR TITLE
Add better test coverage for creation of staff accounts

### DIFF
--- a/app/controllers/staff_users_controller.rb
+++ b/app/controllers/staff_users_controller.rb
@@ -16,7 +16,6 @@ class StaffUsersController < ApplicationController
     if user.save
       render json: { user: user}
     else
-      # ask about better errors!
       render json: user.errors, status: 422
     end
   end

--- a/app/models/cultural_center.rb
+++ b/app/models/cultural_center.rb
@@ -1,4 +1,6 @@
 class CulturalCenter < ApplicationRecord
+  validates :name, presence: true
+
   has_many :staff_users
   has_many :tours
 end

--- a/app/models/staff_user.rb
+++ b/app/models/staff_user.rb
@@ -1,10 +1,10 @@
 class StaffUser < ApplicationRecord
   has_secure_password
 
-  validates :username, uniqueness: true
+  validates :username, uniqueness: true, presence: true
   validates_confirmation_of :password
   validates :password, presence: true, password: true, if: -> { new_record? || changes[:password] }
 
-  belongs_to :cultural_center
+  belongs_to :cultural_center, autosave: true
   has_many :tours
 end

--- a/spec/controllers/staff_users_controller_spec.rb
+++ b/spec/controllers/staff_users_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe StaffUsersController, type: :controller do
 
     it 'creates a staff user when provided valid username, password, and cultural center' do
       create_staff_user("newuser12345", "MoMA")
-
       user = StaffUser.last
       cultural_center = user.cultural_center
 
@@ -51,24 +50,6 @@ RSpec.describe StaffUsersController, type: :controller do
       expect(user.username).to eq("newuser12345")
       expect(cultural_center.name).to eq("MoMA")
       expect(cultural_center.staff_users).to include(user)
-    end
-
-    it 'new staff user is associated with the given cultural center' do
-      create_staff_user("user123", "Met Museum")
-      user = StaffUser.last
-      cultural_center = user.cultural_center
-
-      expect(cultural_center.name).to eq("Met Museum")
-      expect(cultural_center.staff_users).to include(user)
-    end
-
-    it 'if the cultural center already exists, the new user is associated with it' do
-      create_staff_user("user", "MoMA")
-      create_staff_user("user2", "MoMA")
-      user = StaffUser.find_by(username: "user")
-      user2 = StaffUser.find_by(username: "user2")
-
-      expect(user.cultural_center == user2.cultural_center).to eq(true)
     end
 
     it 'staff user and cultural center are not created if cultural center info is invalid' do
@@ -80,7 +61,7 @@ RSpec.describe StaffUsersController, type: :controller do
       expect(cultural_center).to eq(nil)
     end
 
-    it 'staff user and cultural center are not create if user info is invalid' do
+    it 'staff user and cultural center are not created if user info is invalid' do
       create_staff_user("", "Cultural Center")
       user = StaffUser.last
       cultural_center = CulturalCenter.find_by(name: "Cultural Center")

--- a/spec/controllers/staff_users_controller_spec.rb
+++ b/spec/controllers/staff_users_controller_spec.rb
@@ -28,29 +28,66 @@ RSpec.describe StaffUsersController, type: :controller do
   end
 
   context "New Account Authentication" do
-    it 'creates a staff user when provided valid username and password' do
-      user = build :staff_user
+    def create_staff_user(username = "newuser12345", cultural_center = "MoMA")
       post :create, params: {
         user: {
-          username: user.username,
+          username: username,
           password: "bananafeet",
           password_confirmation: "bananafeet"
         },
         cultural_center: {
-          name: user.cultural_center.name
+          name: cultural_center
         }
       }
-      expect(response.status).to eq(200)
-      expect(json['id']).to eq(user.id)
     end
 
-    # TODO
-    # see if user was created and cultural center created
-    # see what happens when user valid, cc in valid
-    # see what happends when user invalid cc valid
-    # in cc model validates name presence
-    # if both valid they are created and associated
-    # auto save true to cc assocation in user model asociation
+    it 'creates a staff user when provided valid username, password, and cultural center' do
+      create_staff_user
+
+      user = StaffUser.all.last
+      cultural_center = user.cultural_center
+
+      expect(response.status).to eq(200)
+      expect(user.username).to eq("newuser12345")
+      expect(cultural_center.name).to eq("MoMA")
+      expect(cultural_center.staff_users).to include(user)
+    end
+
+    it 'new staff user is associated with the given cultural center' do
+      create_staff_user("user123", "Met Museum")
+      user = StaffUser.all.last
+      cultural_center = user.cultural_center
+
+      expect(cultural_center.name).to eq("Met Museum")
+      expect(cultural_center.staff_users).to include(user)
+    end
+
+    it 'if the cultural center already exists, the new user is associated with it' do
+      create_staff_user("user")
+      create_staff_user("user2")
+      user = StaffUser.find_by(username: "user")
+      user2 = StaffUser.find_by(username: "user2")
+
+      expect(user.cultural_center == user2.cultural_center).to eq(true)
+    end
+
+    it 'staff user and cultural center are not created if cultural center info is invalid' do
+      create_staff_user("user", "")
+      user = StaffUser.find_by(username: "user")
+      cultural_center = CulturalCenter.all.last
+
+      expect(user).to eq(nil)
+      expect(cultural_center).to eq(nil)
+    end
+
+    it 'staff user and cultural center are not create if user info is invalid' do
+      create_staff_user("", "Cultural Center")
+      user = StaffUser.all.last
+      cultural_center = CulturalCenter.find_by(name: "Cultural Center")
+
+      expect(user).to eq(nil)
+      expect(cultural_center).to eq(nil)
+    end
 
     it 'returns an error message when the password and confirmation do not match' do
       user = build :staff_user
@@ -64,6 +101,7 @@ RSpec.describe StaffUsersController, type: :controller do
           name: user.cultural_center.name
         }
       }
+
       expect(response.status).to eq(422)
     end
   end

--- a/spec/controllers/staff_users_controller_spec.rb
+++ b/spec/controllers/staff_users_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe StaffUsersController, type: :controller do
     it 'creates a staff user when provided valid username, password, and cultural center' do
       create_staff_user("newuser12345", "MoMA")
 
-      user = StaffUser.all.last
+      user = StaffUser.last
       cultural_center = user.cultural_center
 
       expect(response.status).to eq(200)
@@ -55,7 +55,7 @@ RSpec.describe StaffUsersController, type: :controller do
 
     it 'new staff user is associated with the given cultural center' do
       create_staff_user("user123", "Met Museum")
-      user = StaffUser.all.last
+      user = StaffUser.last
       cultural_center = user.cultural_center
 
       expect(cultural_center.name).to eq("Met Museum")
@@ -74,7 +74,7 @@ RSpec.describe StaffUsersController, type: :controller do
     it 'staff user and cultural center are not created if cultural center info is invalid' do
       create_staff_user("user", "")
       user = StaffUser.find_by(username: "user")
-      cultural_center = CulturalCenter.all.last
+      cultural_center = CulturalCenter.last
 
       expect(user).to eq(nil)
       expect(cultural_center).to eq(nil)
@@ -82,7 +82,7 @@ RSpec.describe StaffUsersController, type: :controller do
 
     it 'staff user and cultural center are not create if user info is invalid' do
       create_staff_user("", "Cultural Center")
-      user = StaffUser.all.last
+      user = StaffUser.last
       cultural_center = CulturalCenter.find_by(name: "Cultural Center")
 
       expect(user).to eq(nil)

--- a/spec/controllers/staff_users_controller_spec.rb
+++ b/spec/controllers/staff_users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StaffUsersController, type: :controller do
   end
 
   context "New Account Authentication" do
-    def create_staff_user(username = "newuser12345", cultural_center = "MoMA")
+    def create_staff_user(username, cultural_center)
       post :create, params: {
         user: {
           username: username,
@@ -42,7 +42,7 @@ RSpec.describe StaffUsersController, type: :controller do
     end
 
     it 'creates a staff user when provided valid username, password, and cultural center' do
-      create_staff_user
+      create_staff_user("newuser12345", "MoMA")
 
       user = StaffUser.all.last
       cultural_center = user.cultural_center
@@ -63,8 +63,8 @@ RSpec.describe StaffUsersController, type: :controller do
     end
 
     it 'if the cultural center already exists, the new user is associated with it' do
-      create_staff_user("user")
-      create_staff_user("user2")
+      create_staff_user("user", "MoMA")
+      create_staff_user("user2", "MoMA")
       user = StaffUser.find_by(username: "user")
       user2 = StaffUser.find_by(username: "user2")
 


### PR DESCRIPTION
Fixed StaffUser controller so that it does not create a user or cultural center if bad data is given for either. Also added better test coverage for the controller. 