### PR TITLE
Add errors to authentication so appropriate error are given when no user is logged in 

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,6 +2,10 @@ module Authentication
   extend ActiveSupport::Concern
   included do
     helper_method :current_staff_user
+
+    rescue_from Token::InvalidError do |error|
+      render status: 401, json: { error: error.message }
+    end
   end
 
   def current_staff_user

--- a/app/javascript/packs/application/App.js
+++ b/app/javascript/packs/application/App.js
@@ -26,11 +26,7 @@ class App extends Component {
 
   authenticateStaffUser = async () => {
     const result = await api.authenticateStaffUser();
-
-    if (result.ok) {
-      this.setState({ currentStaffUser: result.data });
-    }
-
+    this.setState({ currentStaffUser: result.data });
     return result;
   };
 

--- a/app/javascript/packs/application/App.js
+++ b/app/javascript/packs/application/App.js
@@ -19,7 +19,9 @@ class App extends Component {
   state = INITIAL_STATE;
 
   componentDidMount() {
-    this.authenticateStaffUser();
+    if (this.state.currentStaffUser) {
+      this.authenticateStaffUser();
+    }
   }
 
   authenticateStaffUser = async () => {

--- a/app/javascript/packs/application/App.js
+++ b/app/javascript/packs/application/App.js
@@ -19,9 +19,7 @@ class App extends Component {
   state = INITIAL_STATE;
 
   componentDidMount() {
-    if (this.state.currentStaffUser) {
-      this.authenticateStaffUser();
-    }
+    this.authenticateStaffUser();
   }
 
   authenticateStaffUser = async () => {

--- a/app/services/token.rb
+++ b/app/services/token.rb
@@ -1,6 +1,9 @@
 module Token
   extend self
 
+  class InvalidError < StandardError
+  end
+
   def encode(user, expires_in: 2.hours.from_now)
     payload = { id: user.id, exp: expires_in.to_i }
     JWT.encode(payload, secret)
@@ -10,6 +13,8 @@ module Token
     jwt = JWT.decode(token, secret)[0]
     # use fetch so if id doesn't exit then it would return nil, will now raise an error instead
     StaffUser.find(jwt.fetch("id"))
+  rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+    raise InvalidError, "Not authenticated"
   end
 
   private


### PR DESCRIPTION
Was getting a 500 error in the console when I started the local server because it was trying to authenticate a user when there was no user logged in. Added a 401 error instead, which gives more appropriate information.