### PR TITLE
Delete image

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -13,7 +13,7 @@ class PointsController < ApplicationController
   def update
     @point = Point.find(params[:id])
 
-    if @point.update(point_params)
+    if @point.update(validated_params)
       render :show
     else
       render json: @point.errors, status: 422
@@ -42,5 +42,15 @@ class PointsController < ApplicationController
       :directions,
       :image
     )
+  end
+
+  def validated_params
+    validated_params = point_params
+
+    if validated_params.key?(:image) && validated_params[:image].blank?
+      validated_params[:image] = nil
+    end
+
+    return validated_params
   end
 end

--- a/app/javascript/packs/application/components/ImageInput.js
+++ b/app/javascript/packs/application/components/ImageInput.js
@@ -45,7 +45,11 @@ export class ImageInput extends Component {
       <Dropzone name={name} onDrop={this.handleChange} {...config}>
         {preview && <img src={preview} />}
 
-        <p>Drag and drop your image here.</p>
+        {value ? (
+          <p>Drag and drop here to change your image.</p>
+        ) : (
+          <p>Drag and drop your image here.</p>
+        )}
       </Dropzone>
     );
   }

--- a/app/javascript/packs/application/components/PointFormFields.js
+++ b/app/javascript/packs/application/components/PointFormFields.js
@@ -78,7 +78,7 @@ export class PointFormFields extends Component {
           value={image}
         />
         {image && (
-          <Link to="#" onClick={this.handleDeleteImage}>
+          <Link to="#" onClick={this.handleDeleteImage} id="delete-image">
             <i className="fi-trash" /> Remove Image
           </Link>
         )}

--- a/app/javascript/packs/application/components/PointFormFields.js
+++ b/app/javascript/packs/application/components/PointFormFields.js
@@ -55,7 +55,7 @@ export class PointFormFields extends Component {
   handleDeleteImage = event => {
     event.preventDefault();
     this.setState({
-      image: undefined,
+      image: "",
       imageEdited: true
     });
   };

--- a/app/javascript/packs/application/components/PointFormFields.js
+++ b/app/javascript/packs/application/components/PointFormFields.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Button } from "react-foundation";
 import { omit } from "lodash";
 import ImageInput from "./ImageInput";
+import { Link } from "@reach/router";
 
 const INITIAL_STATE = {
   title: "",
@@ -51,20 +52,41 @@ export class PointFormFields extends Component {
     });
   };
 
+  handleDeleteImage = event => {
+    event.preventDefault();
+    this.setState({
+      image: undefined,
+      imageEdited: true
+    });
+  };
+
   render() {
+    const {
+      title,
+      caption,
+      description,
+      location,
+      directions,
+      image
+    } = this.state;
     return (
       <form onSubmit={this.handleSubmit}>
         <label htmlFor="image">Upload Image</label>
         <ImageInput
           name="image"
           onChange={this.handleChangeImage}
-          value={this.state.image}
+          value={image}
         />
+        {image && (
+          <Link to="#" onClick={this.handleDeleteImage}>
+            <i className="fi-trash" /> Remove Image
+          </Link>
+        )}
         <label htmlFor="title">Title: </label>
         <input
           name="title"
           type="text"
-          value={this.state.title}
+          value={title}
           onChange={this.handleChange}
         />
         <br />
@@ -72,7 +94,7 @@ export class PointFormFields extends Component {
         <textarea
           name="caption"
           type="text"
-          value={this.state.caption}
+          value={caption}
           onChange={this.handleChange}
         />
         <br />
@@ -80,7 +102,7 @@ export class PointFormFields extends Component {
         <textarea
           name="description"
           type="text"
-          value={this.state.description}
+          value={description}
           onChange={this.handleChange}
         />
         <br />
@@ -88,7 +110,7 @@ export class PointFormFields extends Component {
         <input
           name="location"
           type="text"
-          value={this.state.location}
+          value={location}
           onChange={this.handleChange}
         />
         <br />
@@ -96,7 +118,7 @@ export class PointFormFields extends Component {
         <textarea
           name="directions"
           type="text"
-          value={this.state.directions}
+          value={directions}
           onChange={this.handleChange}
         />
         <br />

--- a/app/javascript/packs/application/components/PointFormFields.test.js
+++ b/app/javascript/packs/application/components/PointFormFields.test.js
@@ -46,6 +46,32 @@ describe("<PointFormFields />", () => {
     });
   });
 
+  test("handleDeleteImage - when image is deleted handleDeleteImage is called", () => {
+    const onHide = jest.fn();
+    const onSubmit = jest.fn();
+    const values = {
+      title: "Nike of Samothrace",
+      caption: "",
+      description: "",
+      directions: "",
+      location: "",
+      image: "blob:http://localhost:300/a3b6c1fa-93b9"
+    };
+    const component = shallow(
+      <PointFormFields
+        onSubmit={onSubmit}
+        onHide={onHide}
+        initialValues={values}
+      />
+    );
+    component
+      .find("#delete-image")
+      .simulate("click", { preventDefault: () => {} });
+
+    expect(component.state("imageEdited")).toEqual(true);
+    expect(component.state("image")).toEqual(undefined);
+  });
+
   test("onSubmit - when button is clicked the current state is submitted without an image", () => {
     const onSubmit = jest.fn();
     onSubmit.mockResolvedValue({ ok: true, data: { id: 1 } });
@@ -91,7 +117,23 @@ describe("<PointFormFields />", () => {
   });
 
   test("render", () => {
-    const component = setup({});
+    const onHide = jest.fn();
+    const onSubmit = jest.fn();
+    const values = {
+      title: "Nike of Samothrace",
+      caption: "",
+      description: "",
+      directions: "",
+      location: "",
+      image: "blob:http://localhost:300/a3b6c1fa-93b9"
+    };
+    const component = shallow(
+      <PointFormFields
+        onSubmit={onSubmit}
+        onHide={onHide}
+        initialValues={values}
+      />
+    );
     expect(component).toMatchSnapshot();
   });
 });

--- a/app/javascript/packs/application/components/PointFormFields.test.js
+++ b/app/javascript/packs/application/components/PointFormFields.test.js
@@ -69,7 +69,7 @@ describe("<PointFormFields />", () => {
       .simulate("click", { preventDefault: () => {} });
 
     expect(component.state("imageEdited")).toEqual(true);
-    expect(component.state("image")).toEqual(undefined);
+    expect(component.state("image")).toEqual("");
   });
 
   test("onSubmit - when button is clicked the current state is submitted without an image", () => {

--- a/app/javascript/packs/application/components/__snapshots__/PointFormFields.test.js.snap
+++ b/app/javascript/packs/application/components/__snapshots__/PointFormFields.test.js.snap
@@ -12,7 +12,18 @@ exports[`<PointFormFields /> render 1`] = `
   <ImageInput
     name="image"
     onChange={[Function]}
+    value="blob:http://localhost:300/a3b6c1fa-93b9"
   />
+  <[object Object]
+    id="delete-image"
+    onClick={[Function]}
+    to="#"
+  >
+    <i
+      className="fi-trash"
+    />
+     Remove Image
+  </[object Object]>
   <label
     htmlFor="title"
   >
@@ -22,7 +33,7 @@ exports[`<PointFormFields /> render 1`] = `
     name="title"
     onChange={[Function]}
     type="text"
-    value=""
+    value="Nike of Samothrace"
   />
   <br />
   <label

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -6,6 +6,6 @@ class Point < ApplicationRecord
 
   def image=(value)
     image.purge
-    image.attach(value) if value != ""
+    image.attach(value)
   end
 end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -6,6 +6,6 @@ class Point < ApplicationRecord
 
   def image=(value)
     image.purge
-    image.attach(value)
+    image.attach(value) if value != ""
   end
 end

--- a/spec/controllers/points_controller_spec.rb
+++ b/spec/controllers/points_controller_spec.rb
@@ -92,13 +92,29 @@ RSpec.describe PointsController, type: :controller do
       tour_id: tour.id,
       id: json['id'],
       point: new_params,
-      imageEdited: "false",
       format: :json
     }
     point = Point.find(json['id'])
 
     expect(response.status).to eq(200)
     expect(original_image_path).to eq(rails_blob_path(point.image))
+  end
+
+  it 'removes an image when the user deletes it' do
+    post :create, params: { tour_id: tour.id, point: valid_params, format: :json }
+    new_params = {
+      image: ""
+    }
+    patch :update, params: {
+      tour_id: tour.id,
+      id: json['id'],
+      point: new_params,
+      format: :json
+    }
+    point = Point.find(json['id'])
+
+    expect(response.status).to eq(200)
+    expect(point.image.attached?).to eq(false)
   end
 
   it "deletes a point when provided a valid tour id and point id" do


### PR DESCRIPTION
Before this PR a user was only able to change the image associated with a point, now users can remove an image from a point! 
This was accomplished by passing the image prop with a value of undefined so when #image= is called on a point, the existing image is removed and no new image is added. However the point data is being passed to the controller as form data, which means any undefined values are turned into empty strings. To work around this and prevent a 500 error, an image is only attached if its value is not an empty string. 